### PR TITLE
Add SVDKNN

### DIFF
--- a/experiments/default.json
+++ b/experiments/default.json
@@ -1,9 +1,8 @@
 {
 	"configurations": [
         ["svd"],
-        ["svdknn", 20, 5],
-        ["svdknn", 20, 20],
-        ["knn", 20],
-        ["knn", 5]
+        ["svdknn", 30, 5, true],
+        ["svdknn", 20, 5, true],
+        ["svdknn", 20, 2, true]
 	]
 }

--- a/experiments/default.json
+++ b/experiments/default.json
@@ -1,6 +1,9 @@
 {
 	"configurations": [
-        ["svd2"],
-        ["svd"]
+        ["svd"],
+        ["svdknn", 20, 5],
+        ["svdknn", 20, 20],
+        ["knn", 20],
+        ["knn", 5]
 	]
 }

--- a/zero/__init__.py
+++ b/zero/__init__.py
@@ -10,5 +10,6 @@ from .sgd2 import MangakiSGD2
 from .svd import MangakiSVD
 from .svd1 import MangakiSVD1
 from .svd2 import MangakiSVD2
+from .svdknn import MangakiSVDKNN
 from .zero import MangakiZero
 from .lasso import MangakiLASSO

--- a/zero/knn.py
+++ b/zero/knn.py
@@ -34,7 +34,7 @@ def mean_of_nonzero(X, cols):
 @register_algorithm('knn')
 class MangakiKNN(RecommendationAlgorithm):
     def __init__(self, nb_neighbors=20, rated_by_neighbors_at_least=3,
-                 missing_is_mean=True, weighted_neighbors=False, *args,
+                 missing_is_mean=True, weighted_neighbors=False, nb_iterations=None, *args,
                  **kwargs):
         super().__init__(*args, **kwargs)
         self.M = None

--- a/zero/svdknn.py
+++ b/zero/svdknn.py
@@ -42,7 +42,7 @@ class MangakiSVDKNN(RecommendationAlgorithm):
     operations effectively.
     It is 7x faster than svd1.py, and it only relies on numpy/scipy.
     '''
-    def __init__(self, nb_components=20, nb_neighbors=20, nb_iterations=None, *args, **kwargs):
+    def __init__(self, nb_components=20, nb_neighbors=5, nb_iterations=None, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.U = None
         self.sigma = None

--- a/zero/tests/test_zero.py
+++ b/zero/tests/test_zero.py
@@ -58,7 +58,7 @@ def test_fit_predict(
     algo.X_test = X_test
     algo.y_test = y_test
     algo.fit(X_train, y_train)
-    if algo_name in {'als', 'knn', 'sgd', 'svd', 'svd2'}:
+    if algo_name in {'als', 'knn', 'sgd', 'svd', 'svd2', 'svdknn'}:
         user_parameters = algo.fit_single_user([1], [2])
         y_pred = algo.predict_single_user(list(range(nb_works)),
                                           user_parameters)


### PR DESCRIPTION
`python compare.py ../mangaki/notebooks/ratings-mangaki-2022.csv -em ndcg`

    2022-02-05 10:46:09,414 - [__main__] - INFO: Final results
    2022-02-05 10:46:09,414 - [__main__] - INFO: Evaluation of RMSE:
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svd-20]: 1.223803
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svdknn-20-5]: 1.240628
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svdknn-20-20]: 1.252478
    2022-02-05 10:46:09,414 - [__main__] - INFO: [knn-20]: 1.381758
    2022-02-05 10:46:09,414 - [__main__] - INFO: [knn-5]: 1.487427
    2022-02-05 10:46:09,414 - [__main__] - INFO: Evaluation of NDCG:
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svd-20]: 0.855094
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svdknn-20-5]: 0.867029
    2022-02-05 10:46:09,414 - [__main__] - INFO: [svdknn-20-20]: 0.840185
    2022-02-05 10:46:09,414 - [__main__] - INFO: [knn-20]: 0.451067
    2022-02-05 10:46:09,414 - [__main__] - INFO: [knn-5]: 0.410384

Outperforms KNN. Slightly better NDCG, slightly worse RMSE than SVD (good news if we use it to preserve privacy).